### PR TITLE
Add rename task to svg.js in mode 'use'

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -37,6 +37,7 @@ module.exports = ({
             }],
         }))
         .pipe(svgstore())
+        .pipe(gulpRename(`${spriteName}.svg`))
         .pipe(gulp.dest(dest));
     }
     else {


### PR DESCRIPTION
When the svg task has the option mode as 'use', it would not rename the output svg file to the name set in options. Adding the rename task will now name the file to the option `spriteName`.