### PR TITLE
Add removeFill option for svg task with option mode 'use'

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -18,7 +18,7 @@ module.exports = ({
     scssPath = '_sprite.scss'
 }) => {
     if (mode === 'use') {
-        return () => gulp.src(src).pipe(cheerio({
+        return () => gulp.src(src).pipe(gulpif(removeFill, cheerio({
             run: ($) => {
                 $('[fill]').removeAttr('fill');
             },
@@ -26,7 +26,7 @@ module.exports = ({
             parserOptions: {
                 xmlMode: true,
             },
-        }))
+        })))
         .pipe(gulpRename({prefix: prefix}))
         .pipe(svgmin({
             plugins: [{


### PR DESCRIPTION
When I am a developer using SVG `use` syntax
And having control of the SVGs piped through the task
Then I should be able to choose if the task removes the fill's from the SVGs.

Currently if SVGs with a fill (such as flags) go through the pipeline, the fill is removed and ignores the `removeFill` option.