### PR TITLE
Update babel* stuff

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   "homepage": "https://github.com/beamly/gulp-standard-tasks#readme",
   "dependencies": {
     "autoprefixer": "^6.3.6",
-    "babel": "^6.5.2",
-    "babel-core": "^6.7.4",
-    "babel-plugin-transform-es2015-parameters": "^6.7.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babelify": "^7.2.0",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-plugin-transform-es2015-parameters": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
+    "babelify": "^7.3.0",
     "browser-sync": "^2.11.2",
     "browserify": "^13.0.0",
     "browserify-hogan": "^0.3.0",
@@ -55,8 +55,5 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.6.5"
   }
 }


### PR DESCRIPTION
babel-cli is used now, according to their docs: https://babeljs.io/docs/setup/#installation

I don't know babel, so maybe i did something wrong with the changes. But at least errors like:
```
You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.

    npm uninstall -g babel
    npm install --save-dev babel-cli
```
stopped showing up :).