### PR TITLE
Allow media queries not to be repackaged

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -29,15 +29,19 @@ module.exports = ({
     sourcemaps = null,
     browserSync = false,
     rename = {},
-    customSassOptions = {}
+    customSassOptions = {},
+    optimiseMQ = true
 }) => {
     const sourcemapsEnabled = (mode === 'dev' && sourcemaps !== false) || sourcemaps === true;
     const cssoEnabled = (mode === 'prod' && csso !== false) || csso === true;
 
     let processors = [
-        autoprefixerPostCSS({browsers: [autoprefixer]}),
-        mqpackerPostCSS()
+        autoprefixerPostCSS({browsers: [autoprefixer]})
     ];
+    
+    if (optimiseMQ) {
+        processors.push(mqpackerPostCSS());
+    }
 
     if (cssoEnabled) {
         processors.push(cssoPostCSS())


### PR DESCRIPTION
Allow media queries not to be repackaged as in some instances this can cause bugs, default to on for backwards compatibility